### PR TITLE
Fix Mali packages

### DIFF
--- a/.github/workflows/build-gtk.yml
+++ b/.github/workflows/build-gtk.yml
@@ -33,7 +33,7 @@ jobs:
         run: dotnet fsi nugetPreRelease.fsx "" > PreReleaseVersionSuffix.txt
       - name: Build MAUI
         run: |
-            mv Directory.Build.Override.props.in Directory.Build.Override.props
+            sed -i 's/_IncludeAndroid>true/_IncludeAndroid>/g' Directory.Build.Override.props
             dotnet build Microsoft.Maui.BuildTasks.slnf
             dotnet build -c Release Mali.slnf
       - name: Pack MAUI

--- a/.github/workflows/build-gtk.yml
+++ b/.github/workflows/build-gtk.yml
@@ -37,7 +37,7 @@ jobs:
             dotnet build Microsoft.Maui.BuildTasks.slnf
             dotnet build -c Release Mali.slnf
       - name: Pack MAUI
-        run: dotnet pack Mali.slnf --no-build --no-restore
+        run: dotnet pack Mali.slnf
       - name: Upload binaries to nuget (if tag or main branch, and nugetKey is present)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Mali.slnf
+++ b/Mali.slnf
@@ -9,7 +9,8 @@
       "src\\Core\\src\\Core.csproj",
       "src\\Compatibility\\Core\\src\\Compatibility.csproj",
       "src\\Controls\\Foldable\\src\\Controls.Foldable.csproj",
-      "src\\Graphics\\src\\Graphics\\Graphics.csproj"
+      "src\\Graphics\\src\\Graphics\\Graphics.csproj",
+      "src\\Graphics\\src\\Graphics.Gtk\\Graphics.Gtk.csproj"
     ]
   }
 }

--- a/src/Graphics/src/Graphics.Gtk/Graphics.Gtk.csproj
+++ b/src/Graphics/src/Graphics.Gtk/Graphics.Gtk.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0;$(_MauiDotNetTfm)-gtk</TargetFrameworks>
     <RootNamespace>Microsoft.Maui.Graphics.Gtk</RootNamespace>
+    <PackageId>Mali.Graphics.Gtk</PackageId>
   </PropertyGroup>
   <PropertyGroup>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Fixes in building of Mali packages. Add `Graphics.Gtk` package as `Mali.Graphics.Gtk`, because it's needed on GTK platform.