### PR TITLE
Zxing.Net.Maui: build & publish Zxing.Net package

### DIFF
--- a/.github/workflows/build-gtk.yml
+++ b/.github/workflows/build-gtk.yml
@@ -39,10 +39,7 @@ jobs:
       - name: Pack MAUI
         run: dotnet pack Mali.slnf
       - name: Build Mali.ZXing
-        run: |
-            cd src/ZXing.Net.Maui
-            dotnet build -c Release --framework=net8.0-gtk ZXing.Net.MAUI/ZXing.Net.MAUI.csproj
-            dotnet build -c Release --framework=net8.0-gtk ZXing.Net.MAUI.Controls/ZXing.Net.MAUI.Controls.csproj        
+        run: dotnet build -c Release --framework=net8.0-gtk src/ZXing.Net.Maui/ZXing.Net.MAUI.sln
       - name: Pack Mali.ZXing
         run: |
             dotnet pack src/ZXing.Net.Maui/ZXing.Net.MAUI/ZXing.Net.MAUI.csproj --no-build --no-restore

--- a/.github/workflows/build-gtk.yml
+++ b/.github/workflows/build-gtk.yml
@@ -38,6 +38,16 @@ jobs:
             dotnet build -c Release Mali.slnf
       - name: Pack MAUI
         run: dotnet pack Mali.slnf
+      - name: Build Mali.ZXing
+        run: |
+            cd src/ZXing.Net.Maui
+            dotnet build -c Release --framework=net8.0-gtk ZXing.Net.MAUI/ZXing.Net.MAUI.csproj
+            dotnet build -c Release --framework=net8.0-gtk ZXing.Net.MAUI.Controls/ZXing.Net.MAUI.Controls.csproj        
+      - name: Pack Mali.ZXing
+        run: |
+            dotnet pack src/ZXing.Net.Maui/ZXing.Net.MAUI/ZXing.Net.MAUI.csproj --no-build --no-restore
+            dotnet pack src/ZXing.Net.Maui/ZXing.Net.MAUI.Controls/ZXing.Net.MAUI.Controls.csproj --no-build --no-restore       
+                  
       - name: Upload binaries to nuget (if tag or main branch, and nugetKey is present)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/ZXing.Net.Maui/ZXing.Net.MAUI.Controls/ZXing.Net.MAUI.Controls.csproj
+++ b/src/ZXing.Net.Maui/ZXing.Net.MAUI.Controls/ZXing.Net.MAUI.Controls.csproj
@@ -1,22 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net8.0-gtk</TargetFrameworks>
-		<PackageId>ZXing.Net.Maui.Controls</PackageId>
-		<Title>ZXing.Net.MAUI Barcode Scanner for .NET MAUI</Title>
-		<Authors>Redth</Authors>
+		<PackageId>Mali.ZXing.Controls</PackageId>
+		<Title>Mali.ZXing (fork of ZXing.Net.MAUI) Barcode Scanner for .NET MAUI</Title>
+		<Authors>webwarrior-ws,Redth</Authors>
 		<!--<UseMaui>True</UseMaui>-->
 		<SingleProject>True</SingleProject>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<UseSystemResourceKeys>false</UseSystemResourceKeys>
 		<Copyright>Copyright © Redth</Copyright>
-		<PackageProjectUrl>https://github.com/redth/BigIslandBarcoding</PackageProjectUrl>
+		<PackageProjectUrl>https://github.com/nblockchain/Mali/tree/main/src/ZXing.Net.Maui</PackageProjectUrl>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<RepositoryUrl>https://github.com/redth/BigIslandBarcoding</RepositoryUrl>
+		<RepositoryUrl>https://github.com/nblockchain/Mali/tree/main/src/ZXing.Net.Maui</RepositoryUrl>
 		<AssemblyFileVersion>$(PackageVersion)</AssemblyFileVersion>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<OutputType>Library</OutputType>
 	</PropertyGroup>
+	<ItemGroup>
+		<None Include="..\README.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="ZXing.Net" Version="0.16.8" />
 	</ItemGroup>

--- a/src/ZXing.Net.Maui/ZXing.Net.MAUI/ZXing.Net.MAUI.csproj
+++ b/src/ZXing.Net.Maui/ZXing.Net.MAUI/ZXing.Net.MAUI.csproj
@@ -1,15 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net8.0-gtk</TargetFrameworks>
-		<PackageId>ZXing.Net.Maui</PackageId>
-		<Title>ZXing.Net.MAUI Barcode Scanner for .NET MAUI</Title>
-		<Authors>Redth</Authors>
+		<PackageId>Mali.ZXing</PackageId>
+		<Title>Mali.ZXing (fork of ZXing.Net.MAUI) Barcode Scanner for .NET MAUI</Title>
+		<Authors>webwarrior-ws,Redth</Authors>
 		<UseMaui>True</UseMaui>
 		<SingleProject>True</SingleProject>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<UseSystemResourceKeys>false</UseSystemResourceKeys>
 		<Copyright>Copyright © Redth</Copyright>
-		<PackageProjectUrl>https://github.com/redth/ZXing.Net.Maui</PackageProjectUrl>
+		<PackageProjectUrl>https://github.com/nblockchain/Mali/tree/main/src/ZXing.Net.Maui</PackageProjectUrl>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GitThisAssemblyMetadata>True</GitThisAssemblyMetadata>
 		<RepositoryUrl>$(GitRepositoryUrl)</RepositoryUrl>
@@ -27,6 +28,10 @@
 		<MauiPath>$(MSBuildProjectDirectory)\..\..\</MauiPath>
 		<_MauiBuildTasksLocation>$(MauiPath).nuspec\</_MauiBuildTasksLocation>
 	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="..\README.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
 	
 	<ItemGroup Condition="$(TargetPlatformIdentifier) == 'gtk'">
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />


### PR DESCRIPTION
Bulid and publish Zxing.Net.* packages under the names of Mali.Zxing and Mali.ZXing.Controls. This will create nuget packages that can be consumed by geewallet without relying on sources being available through maui submodule.

Reference readme from projects, because now we pack individual projects, and readme file from solution root is not referenced automatically.